### PR TITLE
Remove pingTracker

### DIFF
--- a/pinion_adverts.sp
+++ b/pinion_adverts.sp
@@ -208,7 +208,7 @@ public Action:Event_DoPageHit(Handle:timer, any:user_index)
 		
 		GetClientAuthString(client_index, auth, sizeof(auth));
 		
-		Format(url, sizeof(url), "javascript:pingTracker('%s%s')", g_BaseURL, auth);
+		Format(url, sizeof(url), "%s%s", g_BaseURL, auth);
 
 		ShowMOTDPanelEx(client_index, "", url, MOTDPANEL_TYPE_URL, MOTDPANEL_CMD_NONE, false);
 	}


### PR DESCRIPTION
Removed javascript:pingTracker due to it not being defined and therefore, creating an error which prevented it from loading the "sm_motdpagehit_url" url meaning the ad wouldn't stop playing.
